### PR TITLE
Add AlgoVoi DSPy adapter to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A collection of awesome things regarding DSPy.
 - [OpenInference DSPy Instrumentation](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-dspy)
 - [Opentelemetry tracing for DSPy with Langtrace](https://docs.langtrace.ai/supported-integrations/llm-frameworks/dspy#dspy)
 - [Chemistry Augmented Generationn](https://github.com/scottmreed/chemistry-augmented-generation) MIPRO based optimization of chemical property prediction
+- [AlgoVoi DSPy Adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters/tree/master/ai-agent-frameworks/dspy) - Accept crypto payments (USDC, native ALGO/VOI/HBAR/XLM) inside DSPy pipelines on Algorand, VOI, Hedera, and Stellar — gate signatures behind MPP / x402 / AP2 challenges, verify on-chain payments from `dspy.Module`s.
 
 ### Blogs / Articles
 - [Prompt engineering is a task best left to AI models](https://www.theregister.com/2024/02/22/prompt_engineering_ai_models/)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A collection of awesome things regarding DSPy.
 - [OpenInference DSPy Instrumentation](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-dspy)
 - [Opentelemetry tracing for DSPy with Langtrace](https://docs.langtrace.ai/supported-integrations/llm-frameworks/dspy#dspy)
 - [Chemistry Augmented Generationn](https://github.com/scottmreed/chemistry-augmented-generation) MIPRO based optimization of chemical property prediction
-- [AlgoVoi DSPy Adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters/tree/master/ai-agent-frameworks/dspy) - Accept crypto payments (USDC, native ALGO/VOI/HBAR/XLM) inside DSPy pipelines on Algorand, VOI, Hedera, and Stellar — gate signatures behind MPP / x402 / AP2 challenges, verify on-chain payments from `dspy.Module`s.
+- [AlgoVoi DSPy Adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters/tree/master/ai-agent-frameworks/dspy) - Accept crypto payments (USDC, native ALGO/VOI/HBAR/XLM/ETH/SOL) inside DSPy pipelines on Algorand, VOI, Hedera, Stellar, Base, Solana, and Tempo — gate signatures behind MPP / x402 / AP2 challenges, verify on-chain payments from `dspy.Module`s.
 
 ### Blogs / Articles
 - [Prompt engineering is a task best left to AI models](https://www.theregister.com/2024/02/22/prompt_engineering_ai_models/)


### PR DESCRIPTION
Adds the AlgoVoi DSPy adapter to the **Projects** section.

**AlgoVoi for DSPy** is a crypto payment adapter that lets DSPy pipelines gate signatures behind on-chain payment confirmation - useful for building paid DSPy services, agent-commerce flows, or pay-per-call AI tools.

### Capabilities
- Gate any `dspy.Signature` or `dspy.Module` behind a payment challenge (MPP, x402, or AP2 protocol)
- Verify on-chain payment settlement before executing the module
- Create hosted crypto checkout links programmatically
- Supports USDC + native tokens (ALGO, VOI, HBAR, XLM) across **Algorand, VOI, Hedera, and Stellar** - mainnet + testnet

### Repo
https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters/tree/master/ai-agent-frameworks/dspy

### Quality signals
- 4-chain mainnet smoke tests passing
- Part of a broader AlgoVoi adapter ecosystem (MCP, LangChain, LangGraph, CrewAI, AutoGen, LlamaIndex, etc.)
- Entry placed at the end of Projects (chronological per existing list style)

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*